### PR TITLE
Update CSS test to allow keywords in margin properties

### DIFF
--- a/spec/css_spec.moon
+++ b/spec/css_spec.moon
@@ -30,7 +30,8 @@ describe "sanitize_style", ->
 
   check "margin-left: 50px", "margin-left: 50px;"
   check "margin-left: 50px", "margin-left: 50px"
-  check "", "margin-left: hello"
+  check "margin-left: hello", "margin-left: hello"
+  check "", "padding-left: hello"
 
   check "margin: 10em 10em 10em 10em","margin: 10em 10em 10em 10em;"
   check "margin: 10em 10em", "margin: 10em 10em;"


### PR DESCRIPTION
In 25b285a022cb60c30e3ec611b3edb8e2baf30a73, looks like you wanted to allow keywords in margin properties but not for other properties?  This fixes the build.